### PR TITLE
Fix the version stripping logic

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,7 +84,7 @@
         targets:
           - id: "{{ aws_lambda_result.configuration.function_name }}"
             # Strip off the version number from the arn
-            arn: "{{ (aws_lambda_result.configuration.function_arn.split(':')[:-1])|join(':') }}"
+            arn: "{{ (aws_lambda_result.configuration.function_arn.split(':')[0:7])|join(':') }}"
         schedule_expression: "{{ aws_lambda_schedule_rule_expression }}"
         state: present
       register: aws_lambda_schedule_rule_result


### PR DESCRIPTION
I found that if the lambda has already been created, the lambda module output
of the lambda arn does not have the last 'version' string thus causing issues
with current code. This implement the author fix for it and I tested it
successfully.